### PR TITLE
Add support for Halo65 HE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Untested (Should work I dont have one tho):
 -  NuPhy Halo96
 -  NuPhy Nos75
 
+Tested by contributors:
+- NuPhy Halo65 HE (IcarusSosie)
+
 ## Installation
 
 ### Prerequisites

--- a/nuphy.rules
+++ b/nuphy.rules
@@ -10,16 +10,17 @@
 # type this at the command prompt: sudo cp nuphy.rules /etc/udev/rules.d
 
 
-# Nuphy Air96 v2 -> 3265   
-# Nuphy Air75 v2 -> 3245
-# Nuphy Air60 v2 -> 3255
-# Nuphy Air60 HE -> fee0
-# NuPhy Gem80    -> 3275
-# NuPhy Halo75   -> 32F5
-# NuPhy Halo96   -> 3302
-# NuPhy Nos75    -> 3235
-# NuPhy Kick75   -> 1026
-# NuPhy Dongle   -> 2620
+# Nuphy Air96 v2  -> 3265   
+# Nuphy Air75 v2  -> 3245
+# Nuphy Air60 v2  -> 3255
+# Nuphy Air60 HE  -> fee0
+# NuPhy Gem80     -> 3275
+# NuPhy Halo75    -> 32F5
+# NuPhy Halo96    -> 3302
+# NuPhy Nos75     -> 3235
+# NuPhy Kick75    -> 1026
+# NuPhy Dongle    -> 2620
+# Nuphy Halo65 HE -> 6112
 
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="3265", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="3245", MODE="0666"
@@ -31,6 +32,7 @@ SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idPro
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="fee0", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="1026", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="2620", MODE="0666"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="6112", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="3265", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="3245", MODE="0666"
@@ -42,6 +44,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="3235", MODE="0666
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="fee0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="1026", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="2620", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="6112", MODE="0666"
 # This file should be installed to /etc/udev/rules.d so that you can access Nuphy Devices with via without being root.
 #
 # type this at the command prompt: sudo cp nuphy.rules /etc/udev/rules.d


### PR DESCRIPTION
Hi, thanks for your work on this repo !

I was about to lose it trying to get NuPhy.Io working on fedora, this script and guide made it super easy though.

Here's a quick PR adding support for the Halo65 HE, been using the keyboard for a few hours after editing the keymap and lighting without issues.

I've also added a "Tested by contributors" list in the `README.md`, not sure if you're OK with that, but I figured directing people with model-specific issues away from you and towards the tester might not be such a bad idea :smile: 