### PR TITLE
Add support for NuPhy Node100 Low Profile ISO

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Tested/Added by contributors:
 - NuPhy Node75 LP (FazleArefin)
 - NuPhy Air75 v3 ISO (lyynsch)
 - NuPhy Node100 LP (digit4lsh4d0w)
+- NuPhy Node100 LP ISO (przmkg)
 
 Dongles:
 

--- a/nuphy.rules
+++ b/nuphy.rules
@@ -32,6 +32,7 @@
 # Nuphy Node75 LP Upgrader  -> 0730
 # Nuphy Node100 LP          -> 1037
 # Nuphy Node100 LP Upgrader -> 0737
+# NuPhy Node100 LP ISO      -> 103b
 
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="3265", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="3245", MODE="0666"
@@ -55,6 +56,7 @@ SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idPro
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="0730", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="1037", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="0737", MODE="0666"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="103b", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="3265", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="3245", MODE="0666"
@@ -78,6 +80,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="1030", MODE="0666
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="0730", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="1037", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="0737", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="103b", MODE="0666"
 
 
 # This file should be installed to /etc/udev/rules.d so that you can access Nuphy Devices with via without being root.


### PR DESCRIPTION
This adds support for the NuPhy Node100 Low Profile ISO version. Tested on my own keyboard.