### PR TITLE
Add Field75 HE V2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Untested (Should work I dont have one tho):
 -  NuPhy Nos75
 
 Tested/Added by contributors:
+- NuPhy Field75 HE V2 (vleeuwenmenno)
 - Nuphy Air60 HE (Phrozenn1)
 - Nuphy Kick75 (mfiumara)
 - NuPhy Halo65 HE (IcarusSosie)

--- a/nuphy.rules
+++ b/nuphy.rules
@@ -27,6 +27,7 @@
 # Nuphy Air75 HE            -> 6120
 # NuPhy Air75 v3 ISO        -> 102a
 # NuPhy Field75 HE          -> fe70
+# NuPhy Field75 HE v2       -> 6132
 # NuPhyX BH65               -> 6130
 # Nuphy Node75 LP           -> 1030
 # Nuphy Node75 LP Upgrader  -> 0730
@@ -53,6 +54,7 @@ SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idPro
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="0722", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="6120", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="fe70", MODE="0666"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="6132", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="102a", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="6130", MODE="0666"
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="19f5", ATTR{idProduct}=="1030", MODE="0666"
@@ -80,6 +82,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="1028", MODE="0666
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="0722", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="6120", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="fe70", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="6132", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="102a", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="6130", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idVendor}=="19f5", ATTRS{idProduct}=="1030", MODE="0666"


### PR DESCRIPTION
## Summary

- add USB and hidraw permissions for the Field75 HE V2 (`19f5:6132`)
- list the device as tested by `vleeuwenmenno`

## Why

The repository only covered the original Field75 HE (`19f5:fe70`). The Field75 HE V2 uses product ID `6132`, so NuPhy Drive V2 could detect the keyboard but could not authorize it on Linux.

## Validation

- `udevadm verify nuphy.rules`
- installed the updated rules on Linux and reconnected a physical Field75 HE V2
- confirmed successful authorization and configuration in NuPhy Drive V2 using Helium Browser
